### PR TITLE
HDF5 writer update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ target_link_libraries(sequence_classes_dict PUBLIC ROOT::RIO ROOT::Net)
 
 add_executable(threaded_io_test
   DeserializeStrategy.cc
+  multidataset_plugin.cc
+  H5Timing.cc
   EmptySource.cc
   DummyOutputer.cc
   SerializeOutputer.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake-modules)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3")
+
 find_package(ROOT REQUIRED COMPONENTS Core RIO Tree)
 find_package(TBB REQUIRED)
 find_package(zstd REQUIRED)
@@ -89,6 +91,7 @@ target_link_libraries(threaded_io_test
                               ROOT::RIO
                               ROOT::Tree
                               TBB::tbb
+                              stdc++
                               Threads::Threads
                               configKeys
                               sequence_classes_dict
@@ -109,6 +112,7 @@ target_link_libraries(unroll_test
                               ROOT::RIO
                               ROOT::Tree
                               TBB::tbb
+                              stdc++
                               cms_dict
                               sequence_classes_dict
                               test_classes_dict)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake-modules)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3")
+#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g3")
 
 find_package(ROOT REQUIRED COMPONENTS Core RIO Tree)
 find_package(TBB REQUIRED)
@@ -93,7 +93,6 @@ target_link_libraries(threaded_io_test
                               ROOT::RIO
                               ROOT::Tree
                               TBB::tbb
-                              stdc++
                               Threads::Threads
                               configKeys
                               sequence_classes_dict
@@ -115,7 +114,6 @@ target_link_libraries(unroll_test
                               ROOT::RIO
                               ROOT::Tree
                               TBB::tbb
-                              stdc++
                               cms_dict
                               sequence_classes_dict
                               test_classes_dict)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ target_link_libraries(threaded_io_test
                               configKeys
                               sequence_classes_dict
                               zstd::libzstd_shared
+                              hdf5_hl
                               hdf5)
 
 add_subdirectory(cms)

--- a/H5Timing.cc
+++ b/H5Timing.cc
@@ -1,0 +1,244 @@
+#include "H5Timing.h"
+
+#ifdef H5_TIMING_ENABLE
+
+static H5TimerArray *dataset_timers;
+static H5TimerArray *dataset_sz_timers;
+static H5TimerArray *dataset_read_timers;
+static H5TimerArray *dataset_sz_read_timers;
+static int H5Dwrite_count;
+static int H5Dread_count;
+static double H5Dclose_time;
+static double wrap_requests_time;
+static double merge_requests_time;
+static double H5Dwrite_time;
+static double H5Dread_time;
+static double total_start_time;
+static double total_end_time;
+
+int init_timers() {
+    struct timeval temp_time;
+    dataset_timers = (H5TimerArray*) malloc(sizeof(H5TimerArray)*4);
+    dataset_sz_timers = dataset_timers + 1;
+    dataset_read_timers = dataset_timers + 2;
+    dataset_sz_read_timers = dataset_timers + 3;
+
+    dataset_timers->max_size = 64;
+    dataset_timers->size = 0;
+    dataset_timers->timer_array = (H5Timer*) malloc(sizeof(H5Timer) * dataset_timers->max_size);
+
+    dataset_sz_timers->max_size = 64;
+    dataset_sz_timers->size = 0;
+    dataset_sz_timers->timer_array = (H5Timer*) malloc(sizeof(H5Timer) * dataset_sz_timers->max_size);
+
+    dataset_read_timers->max_size = 64;
+    dataset_read_timers->size = 0;
+    dataset_read_timers->timer_array = (H5Timer*) malloc(sizeof(H5Timer) * dataset_timers->max_size);
+
+    dataset_sz_read_timers->max_size = 64;
+    dataset_sz_read_timers->size = 0;
+    dataset_sz_read_timers->timer_array = (H5Timer*) malloc(sizeof(H5Timer) * dataset_sz_timers->max_size);
+
+    gettimeofday(&temp_time, NULL);
+    total_start_time = (temp_time.tv_usec + temp_time.tv_sec * 1000000) + .0;
+
+    H5Dwrite_count = 0;
+    H5Dread_count = 0;
+
+    H5Dwrite_time = .0;
+    H5Dread_time = .0;
+    wrap_requests_time = .0;
+    merge_requests_time = .0;
+    H5Dclose_time = .0;
+
+    return 0;
+}
+
+static int check_timer_size(H5TimerArray *timers) {
+    H5Timer *temp;
+    if ( timers->size == timers->max_size ) {
+        temp = (H5Timer*) malloc(sizeof(H5Timer) * timers->max_size * 2);
+        memcpy(temp, timers->timer_array, sizeof(H5Timer) * timers->max_size);
+        free(timers->timer_array);
+        timers->timer_array = temp;
+        timers->max_size *= 2;
+        return 1;
+    }
+    return 0;
+}
+
+#define TIMER_START(timers) {                                   \
+    struct timeval temp_time;                                       \
+    check_timer_size(timers);                              \
+    gettimeofday(&temp_time, NULL); \
+    timers->timer_array[timers->size].start = (temp_time.tv_usec + temp_time.tv_sec * 1000000) + .0; \
+    timers->timer_array[timers->size].name = (char*) malloc(sizeof(char) * (strlen(name) + 1)); \
+    strcpy(timers->timer_array[timers->size].name, name); \
+}
+
+#define TIMER_END(timers, data_size) { \
+    struct timeval temp_time;     \
+    gettimeofday(&temp_time, NULL); \
+    timers->timer_array[timers->size].end = (temp_time.tv_usec + temp_time.tv_sec * 1000000) + .0; \
+    timers->timer_array[timers->size].data_size = data_size; \
+    timers->size++; \
+}
+
+int register_timer_start(double *start_time) {
+    struct timeval temp_time;
+    gettimeofday(&temp_time, NULL);
+    *start_time = (temp_time.tv_usec + temp_time.tv_sec * 1000000);
+    return 0;
+}
+
+int register_H5Dclose_timer_end(double start_time) {
+    struct timeval temp_time;
+    gettimeofday(&temp_time, NULL);
+    H5Dclose_time += (temp_time.tv_usec + temp_time.tv_sec * 1000000) - start_time;
+    return 0;
+}
+
+int register_merge_requests_timer_end(double start_time) {
+    struct timeval temp_time;
+    gettimeofday(&temp_time, NULL);
+    merge_requests_time += (temp_time.tv_usec + temp_time.tv_sec * 1000000) - start_time;
+    return 0;
+}
+int register_wrap_requests_timer_end(double start_time) {
+    struct timeval temp_time;
+    gettimeofday(&temp_time, NULL);
+    wrap_requests_time += (temp_time.tv_usec + temp_time.tv_sec * 1000000) - start_time;
+    return 0;
+}
+
+int register_H5Dwrite_timer_end(double start_time) {
+    struct timeval temp_time;
+    gettimeofday(&temp_time, NULL);
+    H5Dwrite_time += (temp_time.tv_usec + temp_time.tv_sec * 1000000) - start_time;
+    return 0;
+}
+
+int register_dataset_timer_start(const char *name) {
+    TIMER_START(dataset_timers);
+    return 0;
+}
+int register_dataset_timer_end(size_t data_size) {
+    TIMER_END(dataset_timers, data_size);
+    return 0;
+}
+
+int register_dataset_sz_timer_start(const char *name) {
+    TIMER_START(dataset_sz_timers);
+    return 0;
+}
+
+int register_dataset_sz_timer_end(size_t data_size) {
+    TIMER_END(dataset_sz_timers, data_size);
+    return 0;
+}
+
+int register_dataset_read_timer_start(const char *name) {
+    TIMER_START(dataset_read_timers);
+    return 0;
+}
+int register_dataset_read_timer_end(size_t data_size) {
+    TIMER_END(dataset_read_timers, data_size);
+    return 0;
+}
+
+int register_dataset_sz_read_timer_start(const char *name) {
+    TIMER_START(dataset_sz_read_timers);
+    return 0;
+}
+
+int register_dataset_sz_read_timer_end(size_t data_size) {
+    TIMER_END(dataset_sz_read_timers, data_size);
+    return 0;
+}
+
+int increment_H5Dwrite() {
+    H5Dwrite_count++;
+    return 0;
+}
+
+int increment_H5Dread() {
+    H5Dread_count++;
+    return 0;
+}
+
+int record_timer(H5TimerArray *timer, const char* filename) {
+    FILE *stream;
+    size_t i, total_mem_size;
+    double total_time = 0, min_time = -1, max_time = -1;
+    stream = fopen(filename, "w");
+    fprintf(stream, "dataset_name,start,end,elapse,data_size\n");
+    total_mem_size = 0;
+    for ( i = 0; i < timer->size; ++i ) {
+        fprintf(stream, "%s, %lf, %lf, %lf, %zu\n", timer->timer_array[i].name, timer->timer_array[i].start, timer->timer_array[i].end, (timer->timer_array[i].end - timer->timer_array[i].start)/1000000, timer->timer_array[i].data_size);
+        total_time += (timer->timer_array[i].end - timer->timer_array[i].start)/1000000;
+        if (min_time == -1 || min_time > timer->timer_array[i].start) {
+            min_time = timer->timer_array[i].start;
+        }
+        if (max_time == -1 || max_time < timer->timer_array[i].end) {
+            max_time = timer->timer_array[i].end;
+        }
+        total_mem_size += timer->timer_array[i].data_size;
+    }
+    fprintf(stream, "total,%lf,%lf,%lf,%zu\n", min_time, max_time, total_time, total_mem_size);
+    fclose(stream);
+    return 0;
+}
+
+int output_results() {
+    printf("total H5Dwrite calls = %d, H5Dread calls = %d\n", H5Dwrite_count, H5Dread_count);
+    if ( dataset_timers->size ) {
+        record_timer(dataset_timers, "dataset_write_record.csv");
+    }
+    if ( dataset_sz_timers->size ) {
+        record_timer(dataset_sz_timers, "dataset_sz_write_record.csv");
+    }
+    if ( dataset_read_timers->size ) {
+        record_timer(dataset_read_timers, "dataset_read_record.csv");
+    }
+    if ( dataset_sz_read_timers->size ) {
+        record_timer(dataset_sz_read_timers, "dataset_sz_read_record.csv");
+    }
+    return 0;
+}
+
+int finalize_timers() {
+    size_t i;
+    struct timeval temp_time;
+    output_results();
+
+    gettimeofday(&temp_time, NULL);
+    total_end_time = (temp_time.tv_usec + temp_time.tv_sec * 1000000) + .0;
+    printf("total program time is %lf, H5Dwrite time = %lf, H5Dread time = %lf\n", (total_end_time - total_start_time) / 1000000, H5Dwrite_time / 1000000, H5Dread_time / 1000000);
+    printf("merge requests time = %lf, wrap requests time = %lf, H5Dclose = %lf\n", merge_requests_time / 1000000, wrap_requests_time / 1000000, H5Dclose_time / 1000000);
+
+    for ( i = 0 ; i < dataset_timers->size; ++i ) {
+        free(dataset_timers->timer_array[i].name);
+    }
+
+    for ( i = 0 ; i < dataset_sz_timers->size; ++i ) {
+        free(dataset_sz_timers->timer_array[i].name);
+    }
+
+    for ( i = 0 ; i < dataset_read_timers->size; ++i ) {
+        free(dataset_read_timers->timer_array[i].name);
+    }
+
+    for ( i = 0 ; i < dataset_sz_read_timers->size; ++i ) {
+        free(dataset_sz_read_timers->timer_array[i].name);
+    }
+
+    free(dataset_timers->timer_array);
+    free(dataset_sz_timers->timer_array);
+
+    free(dataset_read_timers->timer_array);
+    free(dataset_sz_read_timers->timer_array);
+
+    free(dataset_timers);
+    return 0;
+}
+#endif

--- a/H5Timing.h
+++ b/H5Timing.h
@@ -1,0 +1,45 @@
+#ifndef H5_TIMING_H
+
+#define H5_TIMING_H
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
+#include <unistd.h>
+#undef H5_TIMING_ENABLE
+
+#ifdef H5_TIMING_ENABLE
+typedef struct{
+    double start;
+    double end;
+    size_t data_size;
+    char *name;
+} H5Timer;
+
+typedef struct{
+    H5Timer *timer_array;
+    size_t max_size;
+    size_t size;
+} H5TimerArray;
+
+int init_timers();
+int register_timer_start(double *start_time);
+int register_merge_requests_timer_end(double start_time);
+int register_wrap_requests_timer_end(double start_time);
+int register_H5Dclose_timer_end(double start_time);
+int register_H5Dwrite_timer_end(double start_time);
+
+int register_dataset_timer_start(const char *name);
+int register_dataset_timer_end(size_t data_size);
+int register_dataset_sz_timer_start(const char *name);
+int register_dataset_sz_timer_end(size_t data_size);
+int register_dataset_read_timer_start(const char *name);
+int register_dataset_read_timer_end(size_t data_size);
+int register_dataset_sz_read_timer_start(const char *name);
+int register_dataset_sz_read_timer_end(size_t data_size);
+int increment_H5Dwrite();
+int increment_H5Dread();
+int finalize_timers();
+#endif
+
+#endif

--- a/HDFOutputer.cc
+++ b/HDFOutputer.cc
@@ -8,6 +8,8 @@
 #include <cstring>
 #include <cmath>
 #include <set>
+#include "H5Timing.h"
+#include "multidataset_plugin.h"
 
 int max_batch_size = 2;
 int hdf_method = -1;

--- a/HDFOutputer.cc
+++ b/HDFOutputer.cc
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <cmath>
 #include <set>
+#include <hdf5_hl.h>
 #include "H5Timing.h"
 #include "multidataset_plugin.h"
 

--- a/HDFOutputer.cc
+++ b/HDFOutputer.cc
@@ -9,6 +9,10 @@
 #include <cmath>
 #include <set>
 
+int max_batch_size = 2;
+int hdf_method = -1;
+int total_n_events = -1;
+
 using namespace cce::tf;
 using product_t = std::vector<char>; 
 
@@ -121,7 +125,7 @@ HDFOutputer::output(EventIdentifier const& iEventID,
   size_t total_data_size = 0;
 #endif
   char *p = getenv("HEP_IO_TYPE");
-  int method = 0;
+  int method = hdf_method;
 
   if ( p != NULL ) {
     method = atoi(p);

--- a/RootEventOutputer.cc
+++ b/RootEventOutputer.cc
@@ -169,7 +169,7 @@ std::pair<std::vector<uint32_t>, std::vector<char>> RootEventOutputer::writeData
       auto offset = offsets[index++];
       std::copy(s.blob().begin(), s.blob().end(), buffer.begin()+offset );
     }
-    assert(buffer.size() == offset[index]);
+    assert(buffer.size() == offsets[index]);
   }
 
   auto cBuffer  = compressBuffer(buffer);

--- a/multidataset_plugin.cc
+++ b/multidataset_plugin.cc
@@ -1,0 +1,567 @@
+#include "multidataset_plugin.h"
+
+
+static multidataset_array *multi_datasets;
+/*
+static hid_t *dataset_recycle;
+static hid_t *memspace_recycle;
+static hid_t *dataspace_recycle;
+*/
+static int dataset_size;
+static int dataset_size_limit;
+
+/*
+static int dataset_recycle_size;
+static int dataset_recycle_size_limit;
+static int dataspace_recycle_size;
+static int dataspace_recycle_size_limit;
+static int memspace_recycle_size;
+static int memspace_recycle_size_limit;
+*/
+hsize_t total_data_size;
+
+#define MEM_SIZE 2048
+#define MAX_DATASET 65536
+
+int init_multidataset() {
+    dataset_size = 0;
+    dataset_size_limit = 0;
+/*
+    dataspace_recycle_size = 0;
+    dataspace_recycle_size_limit = 0;
+    memspace_recycle_size = 0;
+    memspace_recycle_size_limit = 0;
+    dataset_recycle_size_limit = 0;
+    dataset_recycle_size = 0;
+*/
+    return 0;
+}
+
+int finalize_multidataset() {
+    int i, j;
+
+    for ( i = 0; i < dataset_size; ++i ) {
+        free(multi_datasets[i].name);
+        free(multi_datasets[i].start);
+        for ( j = 0; j < multi_datasets[i].request_size; ++j ) {
+            free(multi_datasets[i].temp_mem[j]);
+        }
+        free(multi_datasets[i].temp_mem);
+        if (multi_datasets[i].did != -1) {
+            H5Dclose(multi_datasets[i].did);
+        }
+    }
+    free(multi_datasets);
+    dataset_size = 0;
+    return 0;
+}
+
+#if 0
+int register_dataset_recycle(hid_t did) {
+    if (dataset_recycle_size == dataset_recycle_size_limit) {
+        if ( dataset_recycle_size_limit > 0 ) {
+            dataset_recycle_size_limit *= 2;
+            hid_t *temp = (hid_t*) malloc(dataset_recycle_size_limit*sizeof(hid_t));
+            memcpy(temp, dataset_recycle, sizeof(hid_t) * dataset_recycle_size);
+            free(dataset_recycle);
+            dataset_recycle = temp;
+        } else {
+            dataset_recycle_size_limit = MEM_SIZE;
+            dataset_recycle = (hid_t*) malloc(dataset_recycle_size_limit*sizeof(hid_t));
+        }
+    }
+    dataset_recycle[dataset_recycle_size] = did;
+    dataset_recycle_size++;
+    return 0;
+}
+
+
+int register_dataspace_recycle(hid_t dsid) {
+    if (dataspace_recycle_size == dataspace_recycle_size_limit) {
+        if ( dataspace_recycle_size_limit > 0 ) {
+            dataspace_recycle_size_limit *= 2;
+            hid_t *temp = (hid_t*) malloc(dataspace_recycle_size_limit*sizeof(hid_t));
+            memcpy(temp, dataspace_recycle, sizeof(hid_t) * dataspace_recycle_size);
+            free(dataspace_recycle);
+            dataspace_recycle = temp;
+        } else {
+            dataspace_recycle_size_limit = MEM_SIZE;
+            dataspace_recycle = (hid_t*) malloc(dataspace_recycle_size_limit*sizeof(hid_t));
+        }
+    }
+    dataspace_recycle[dataspace_recycle_size] = dsid;
+    dataspace_recycle_size++;
+    return 0;
+}
+
+int register_memspace_recycle(hid_t msid) {
+    if (memspace_recycle_size == memspace_recycle_size_limit) {
+        if ( memspace_recycle_size_limit > 0 ) {
+            memspace_recycle_size_limit *= 2;
+            hid_t *temp = (hid_t*) malloc(memspace_recycle_size_limit*sizeof(hid_t));
+            memcpy(temp, memspace_recycle, sizeof(hid_t) * memspace_recycle_size);
+            free(memspace_recycle);
+            memspace_recycle = temp;
+        } else {
+            memspace_recycle_size_limit = MEM_SIZE;
+            memspace_recycle = (hid_t*) malloc(memspace_recycle_size_limit*sizeof(hid_t));
+        }
+    }
+    memspace_recycle[memspace_recycle_size] = msid;
+    memspace_recycle_size++;
+    return 0;
+}
+#endif
+
+static hid_t get_dataset_id(const char* name, hid_t gid) {
+    int i;
+    for ( i = 0; i < dataset_size; ++i ) {
+        if (strcmp(name, multi_datasets[i].name) == 0) {
+            if (multi_datasets[i].did != -1) {
+                return multi_datasets[i].did;
+            }
+            break;
+        }
+    }
+    multi_datasets[i].did = H5Dopen2(gid, name, H5P_DEFAULT);
+    return multi_datasets[i].did;
+}
+
+static int wrap_hdf5_spaces(const char *name, int total_requests, hsize_t *start, hsize_t *end, hid_t did, hid_t* dsid_ptr, hid_t *msid_ptr) {
+    const hsize_t ndims = 1;
+    hsize_t old_dims[ndims]; //our datasets are 1D
+    hsize_t new_dims[ndims];
+    hsize_t max_dims[ndims]; //= {H5S_UNLIMITED};
+    hsize_t max_offset, data_size, total_data_size;
+    hid_t dsid, msid;
+    int i;
+
+    dsid = H5Dget_space(did);
+    H5Sget_simple_extent_dims(dsid, old_dims, max_dims);
+    
+    max_offset = end[0];
+    for ( i = 1; i < total_requests; ++i ) {
+        if ( max_offset < end[i] ) {
+            max_offset = end[i];
+        }
+    }
+    if (max_offset > old_dims[0]) {
+        new_dims[0] = max_offset;
+        H5Dset_extent(did, new_dims);
+        H5Sclose(dsid);
+        dsid = H5Dget_space(did);
+    }
+
+    data_size = end[0] - start[0];
+    H5Sselect_hyperslab(dsid, H5S_SELECT_SET, start, NULL, &data_size, NULL);
+    total_data_size = data_size;
+    for ( i = 1; i < total_requests; ++i ) {
+        data_size = end[i] - start[i];
+        total_data_size += data_size;
+        H5Sselect_hyperslab(dsid, H5S_SELECT_OR, start + i, NULL, &data_size, NULL);
+    }
+    max_dims[0] = H5S_UNLIMITED;
+    msid = H5Screate_simple(ndims, &total_data_size, max_dims);
+
+    *dsid_ptr = dsid;
+    *msid_ptr = msid;
+    return 0;
+}
+
+int register_multidataset_request(const char *name, hid_t gid, void *buf, hsize_t start, hsize_t end, hid_t mtype) {
+    size_t esize = H5Tget_size (mtype) * (end - start);
+    hsize_t *temp_offset;
+    int i;
+    int index = -1;
+    char** temp_mem;
+
+    for ( i = 0; i < dataset_size; ++i ) {
+        if ( strcmp(name, multi_datasets[i].name) == 0 ) {
+            index = i;
+            break;
+        }
+    }
+    if ( index == -1 ) {
+        if ( dataset_size == dataset_size_limit ) {
+            if ( dataset_size_limit ) {
+                dataset_size_limit *= 2;
+                multidataset_array *temp = (multidataset_array*) malloc(dataset_size_limit*sizeof(multidataset_array));
+                memcpy(temp, multi_datasets, sizeof(multidataset_array) * dataset_size);
+                free(multi_datasets);
+                multi_datasets = temp;
+
+            } else {
+                dataset_size_limit = MEM_SIZE;
+                multi_datasets = (multidataset_array*) malloc(dataset_size_limit*sizeof(multidataset_array));
+            }
+        }
+        index = dataset_size;
+        multi_datasets[index].name = strdup(name);
+        multi_datasets[index].did = H5Dopen2(gid, name, H5P_DEFAULT);
+        multi_datasets[index].request_size_limit = MEM_SIZE;
+        multi_datasets[index].request_size = 0;
+        multi_datasets[index].temp_mem = (char**) malloc(sizeof(char**) * multi_datasets[index].request_size_limit);
+        multi_datasets[index].start = (hsize_t*) malloc(2 * sizeof(hsize_t) * multi_datasets[index].request_size_limit);
+        multi_datasets[index].end = multi_datasets[index].start + multi_datasets[index].request_size_limit;
+        multi_datasets[index].mtype = mtype;
+
+        dataset_size++;
+    }
+
+    if (multi_datasets[index].request_size_limit == multi_datasets[index].request_size) {
+        multi_datasets[index].request_size_limit *= 2;
+        temp_mem = (char**) malloc(sizeof(char*) * multi_datasets[index].request_size_limit);
+        temp_offset = (hsize_t*) malloc(sizeof(hsize_t) * multi_datasets[index].request_size_limit * 2);
+        memcpy(temp_mem, multi_datasets[index].temp_mem, sizeof(char*) * multi_datasets[index].request_size);
+        memcpy(temp_offset, multi_datasets[index].start, sizeof(hsize_t) * multi_datasets[index].request_size);
+        memcpy(temp_offset + multi_datasets[index].request_size_limit, multi_datasets[index].end, sizeof(hsize_t) * multi_datasets[index].request_size);
+
+        free(multi_datasets[index].temp_mem);
+        free(multi_datasets[index].start);
+
+        multi_datasets[index].temp_mem = temp_mem;
+        multi_datasets[index].start = temp_offset;
+        multi_datasets[index].end = temp_offset + multi_datasets[index].request_size_limit;
+
+    }
+    if (multi_datasets[index].did == -1) {
+        multi_datasets[index].did = H5Dopen2(gid, name, H5P_DEFAULT);
+    }
+    multi_datasets[index].start[multi_datasets[index].request_size] = start;
+    multi_datasets[index].end[multi_datasets[index].request_size] = end;
+    multi_datasets[index].temp_mem[multi_datasets[index].request_size] = (char*) malloc(esize);
+    memcpy(multi_datasets[index].temp_mem[multi_datasets[index].request_size], buf, esize);
+    multi_datasets[index].last_end = end;
+
+    multi_datasets[index].request_size++;
+
+    return 0;
+}
+
+int register_multidataset_request_append(const char *name, hid_t gid, void *buf, hsize_t data_size, hid_t mtype) {
+    int i;
+    int index = -1;
+    hsize_t start, end;
+    for ( i = 0; i < dataset_size; ++i ) {
+        if ( strcmp(name, multi_datasets[i].name) == 0 ) {
+            index = i;
+            break;
+        }
+    }
+    if (index != -1) {
+        start = multi_datasets[index].last_end;
+        end = multi_datasets[index].last_end + data_size;
+    } else {
+        start = 0;
+        end = data_size;
+    }
+
+    register_multidataset_request(name, gid, buf, start, end, mtype);
+    return 0;
+}
+
+static int merge_requests(hsize_t *start, hsize_t *end, int request_size, char** buf, hsize_t **new_start, hsize_t **new_end, char** new_buf, hid_t mtype, int *request_size_ptr) {
+    int i, index;
+    int merged_requests = request_size;
+    char* ptr;
+    size_t esize = H5Tget_size (mtype);
+    size_t total_data_size = end[0] - start[0];
+
+    for ( i = 1; i < request_size; ++i ) {
+        total_data_size += end[i] - start[i];
+        if ( end[i-1] == start[i] ) {
+            merged_requests--;
+        }
+    }
+    *new_start = (hsize_t*) malloc(sizeof(hsize_t) * merged_requests * 2);
+    *new_end = new_start[0] + merged_requests;
+
+    index = 0;
+    new_start[0][0] = start[0];
+    new_end[0][0] = end[0];
+
+
+    *new_buf = (char*) malloc(esize * total_data_size);
+    ptr = *new_buf;
+    memcpy(ptr, buf[0], (end[0] - start[0]) * esize);
+    ptr += (end[0] - start[0]) * esize;
+    free(buf[0]);
+    for ( i = 1; i < request_size; ++i ) {
+        memcpy(ptr, buf[i], (end[i] - start[i]) * esize);
+        ptr += (end[i] - start[i]) * esize;
+        free(buf[i]);
+
+        if ( end[i-1] < start[i] ) {
+            index++;
+            new_start[0][index] = start[i];
+        }
+        new_end[0][index] = end[i];
+    }
+    *request_size_ptr = merged_requests;
+    return 0;
+}
+
+#if 0
+int register_multidataset(const char *name, void *buf, hid_t did, hid_t dsid, hid_t msid, hid_t mtype, int write) {
+    int i;
+    hsize_t dims[H5S_MAX_RANK];
+    hsize_t mdims[H5S_MAX_RANK];
+    hsize_t start[H5S_MAX_RANK];
+    hsize_t end[H5S_MAX_RANK];
+    char *tmp_buf;
+    hsize_t data_size, total_data_size;
+    hsize_t zero = 0;
+    size_t esize = H5Tget_size (mtype);
+
+    if (write) {
+        for ( i = 0; i < dataset_size; ++i ) {
+            if (strcmp(name, multi_datasets[i].name) == 0) {
+                /* Extract data size from input memory space */
+                H5Sget_simple_extent_dims(msid, &data_size, mdims);
+                /* Reset dataspace for existing dataset */
+                H5Sget_simple_extent_dims(multi_datasets[i].dsid, dims, mdims);
+                dims[0] += data_size;
+                H5Sget_select_bounds(multi_datasets[i].dsid, start, end );
+                H5Sset_extent_simple( multi_datasets[i].dsid, 1, dims, dims );
+                /* Reset the end size to slab size*/
+                end[0] = end[0] + data_size;
+                /* Add the new selection */
+                H5Sselect_none(multi_datasets[i].dsid);
+                H5Sselect_hyperslab(multi_datasets[i].dsid, H5S_SELECT_SET, start, NULL, end, NULL);
+                H5Sclose(dsid);
+
+                /* Reset the existing memory space directly to the current data size */
+                H5Sget_simple_extent_dims(multi_datasets[i].msid, dims, mdims);
+                dims[0] += data_size;
+                total_data_size = dims[0];
+                H5Sset_extent_simple( multi_datasets[i].msid, 1, dims, dims );
+                H5Sselect_all( multi_datasets[i].msid );
+                H5Sclose(msid);
+
+                tmp_buf = multi_datasets[i].temp_mem;
+                multi_datasets[i].temp_mem = (char*) malloc(esize * total_data_size);
+                memcpy(temp_mem[dataset_size], tmp_buf, esize * (total_data_size - data_size) );
+                memcpy(temp_mem[dataset_size] + esize * (total_data_size - data_size), buf, esize * data_size );
+
+                free(tmp_buf);
+                multi_datasets[dataset_size].u.wbuf = temp_mem[dataset_size];
+
+                H5Dclose(did);
+                return 0;
+            }
+        }
+    }
+
+    H5Sget_simple_extent_dims (msid, dims, mdims);
+    esize *= dims[0];
+
+    if (dataset_size == dataset_size_limit) {
+        if ( dataset_size_limit ) {
+            dataset_size_limit *= 2;
+            multidataset_array *temp = (multidataset_array*) malloc(dataset_size_limit*sizeof(multidataset_array));
+            memcpy(temp, multi_datasets, sizeof(multidataset_array) * dataset_size);
+            free(multi_datasets);
+            multi_datasets = temp;
+
+            char **new_memory = (char**) malloc(dataset_size_limit*sizeof(char*));
+            memcpy(new_memory, temp_mem, sizeof(char*) * dataset_size);
+            free(temp_mem);
+            temp_mem = new_memory;
+        } else {
+            dataset_size_limit = MEM_SIZE;
+            temp_mem = (char**) malloc(sizeof(char*) * dataset_size_limit);
+            multi_datasets = (multidataset_array*) malloc(dataset_size_limit*sizeof(multidataset_array));
+        }
+    }
+
+    multi_datasets[dataset_size].msid = msid;
+    multi_datasets[dataset_size].did = did;
+    multi_datasets[dataset_size].dsid = dsid;
+    multi_datasets[dataset_size].mtype = mtype;
+    strcpy(multi_datasets[dataset_size].name, name);
+    if (write) {
+        temp_mem[dataset_size] = (char*) malloc(esize);
+        memcpy(temp_mem[dataset_size], buf, esize);
+        multi_datasets[dataset_size].u.wbuf = temp_mem[dataset_size];
+    } else {
+        multi_datasets[dataset_size].u.rbuf = buf;
+    }
+    dataset_size++;
+
+    register_dataset_recycle(did);
+    register_dataspace_recycle(dsid);
+    register_memspace_recycle(msid);
+    return 0;
+}
+
+int check_write_status() {
+    if (dataset_size < MAX_DATASET) {
+        return 0;
+    }
+#ifdef H5_TIMING_ENABLE
+    register_dataset_timer_start("flush_all");
+#endif
+    flush_multidatasets();
+    dataset_recycle_all();
+    dataspace_recycle_all();
+    memspace_recycle_all();
+#ifdef H5_TIMING_ENABLE
+    register_dataset_timer_end(total_data_size);
+#endif
+
+    return 0;
+}
+
+int dataset_recycle_all() {
+    int i;
+    for ( i = 0; i < dataset_recycle_size; ++i ) {
+        if ( dataset_recycle[i] >= 0 ) {
+            H5Dclose(dataset_recycle[i]);
+        }
+    }
+    if (dataset_recycle_size) {
+        free(dataset_recycle);
+    }
+    dataset_recycle_size = 0;
+    dataset_recycle_size_limit = 0;
+    return 0;
+}
+
+
+int dataspace_recycle_all() {
+    int i;
+    //printf("recycle %d dataspace\n", dataspace_recycle_size);
+    for ( i = 0; i < dataspace_recycle_size; ++i ) {
+        if ( dataspace_recycle[i] >= 0 ) {
+            H5Sclose(dataspace_recycle[i]);
+        }
+    }
+    if (dataspace_recycle_size) {
+        free(dataspace_recycle);
+    }
+    dataspace_recycle_size = 0;
+    dataspace_recycle_size_limit = 0;
+    return 0;
+}
+
+int memspace_recycle_all() {
+    int i;
+    //printf("recycle %d memspace\n", memspace_recycle_size);
+    for ( i = 0; i < memspace_recycle_size; ++i ) {
+        if ( memspace_recycle[i] >= 0 ){
+            H5Sclose(memspace_recycle[i]);
+        }
+    }
+    if (memspace_recycle_size) {
+        free(memspace_recycle);
+    }
+    memspace_recycle_size = 0;
+    memspace_recycle_size_limit = 0;
+    return 0;
+}
+#endif
+
+int flush_multidatasets() {
+    int i, j;
+    size_t esize;
+    hsize_t dims[H5S_MAX_RANK], mdims[H5S_MAX_RANK];
+    H5D_rw_multi_t *multi_datasets_temp;
+    hsize_t *new_start, *new_end;
+    int new_request_size;
+    hid_t msid, dsid;
+    char **temp_buf = (char**) malloc(sizeof(char*) * dataset_size);
+#ifdef H5_TIMING_ENABLE
+    double start_time;
+#endif
+
+    //printf("Rank %d number of datasets to be written %d\n", rank, dataset_size);
+#if ENABLE_MULTIDATASET==1
+    #ifdef H5_TIMING_ENABLE
+    increment_H5Dwrite();
+    #endif
+    multi_datasets_temp = (H5D_rw_multi_t*) malloc(sizeof(H5D_rw_multi_t) * dataset_size);
+
+    for ( i = 0; i < dataset_size; ++i ) {
+        if (multi_datasets[i].did == -1) {
+            continue;
+        }
+
+        //MPI_Barrier(MPI_COMM_WORLD);
+        #ifdef H5_TIMING_ENABLE
+        increment_H5Dwrite();
+        #endif
+
+        merge_requests(multi_datasets[i].start, multi_datasets[i].end, multi_datasets[i].request_size, multi_datasets[i].buf, &new_start, &new_end, &(temp_buf[i]), multi_datasets[i].mtype, &new_request_size);
+        multi_datasets_temp[i].dset_id = multi_datasets[i].did;
+        multi_datasets_temp[i].mem_type_id = multi_datasets[i].mtype;
+        multi_datasets_temp[i].u.wbuf = temp_buf[i];
+
+        wrap_hdf5_spaces(multi_datasets[i].name, new_request_size, new_start, new_end, multi_datasets[i].did, &(multi_datasets_temp[i].dset_space_id), &(multi_datasets_temp[i].mem_space_id));
+    }
+
+    H5Dwrite_multi(H5P_DEFAULT, dataset_size, multi_datasets_temp);
+
+    for ( i = 0; i < dataset_size; ++i ) {
+        if (multi_datasets[i].did == -1) {
+            continue;
+        }
+        H5Sclose(multi_datasets_temp[i].dset_space_id);
+        H5Sclose(multi_datasets_temp[i].mem_space_id);
+        H5Dclose(multi_datasets[i].did);
+        multi_datasets[i].did = -1;
+        free(temp_buf[i]);
+    }
+
+    free(multi_datasets_temp);
+#else
+    //printf("rank %d has dataset_size %lld\n", rank, (long long int) dataset_size);
+    for ( i = 0; i < dataset_size; ++i ) {
+        if (multi_datasets[i].did == -1) {
+            continue;
+        }
+        #ifdef H5_TIMING_ENABLE
+        increment_H5Dwrite();
+        #endif
+#ifdef H5_TIMING_ENABLE
+        register_timer_start(&start_time);
+#endif
+        merge_requests(multi_datasets[i].start, multi_datasets[i].end, multi_datasets[i].request_size, multi_datasets[i].temp_mem, &new_start, &new_end, &(temp_buf[i]), multi_datasets[i].mtype, &new_request_size);
+#ifdef H5_TIMING_ENABLE
+        register_merge_requests_timer_end(start_time);
+#endif
+
+#ifdef H5_TIMING_ENABLE
+        register_timer_start(&start_time);
+#endif
+        wrap_hdf5_spaces(multi_datasets[i].name, new_request_size, new_start, new_end, multi_datasets[i].did, &dsid, &msid);
+#ifdef H5_TIMING_ENABLE
+        register_wrap_requests_timer_end(start_time);
+#endif
+
+        multi_datasets[i].request_size = 0;
+
+#ifdef H5_TIMING_ENABLE
+        register_timer_start(&start_time);
+#endif
+        H5Dwrite (multi_datasets[i].did, multi_datasets[i].mtype, msid, dsid, H5P_DEFAULT, temp_buf[i]);
+#ifdef H5_TIMING_ENABLE
+        register_H5Dwrite_timer_end(start_time);
+#endif
+
+        H5Sclose(dsid);
+        H5Sclose(msid);
+#ifdef H5_TIMING_ENABLE
+        register_timer_start(&start_time);
+#endif
+        H5Dclose(multi_datasets[i].did);
+#ifdef H5_TIMING_ENABLE
+        register_H5Dclose_timer_end(start_time);
+#endif
+        multi_datasets[i].did = -1;
+        free(temp_buf[i]);
+    }
+#endif
+
+    free(temp_buf);
+    return 0;
+}

--- a/multidataset_plugin.h
+++ b/multidataset_plugin.h
@@ -1,0 +1,53 @@
+#ifndef MULTIDATASET_PLUGIN_H
+#define MULTIDATASET_PLUGIN_H
+
+//#include <mpi.h>
+#include <stdlib.h>
+#include <string.h>
+#include <hdf5.h>
+#include "H5Timing.h"
+#define ENABLE_MULTIDATASET 0
+#define MULTIDATASET_DEFINE 1
+
+#if MULTIDATASET_DEFINE == 1
+typedef struct H5D_rw_multi_t
+{
+    hid_t dset_id;          /* dataset ID */
+    hid_t dset_space_id;    /* dataset selection dataspace ID */
+    hid_t mem_type_id;      /* memory datatype ID */
+    hid_t mem_space_id;     /* memory selection dataspace ID */
+    union {
+        void *rbuf;         /* pointer to read buffer */
+        const void *wbuf;   /* pointer to write buffer */
+    } u;
+} H5D_rw_multi_t;
+#endif
+
+typedef struct multidataset_array {
+    char *name;
+    hsize_t *start;
+    hsize_t *end;
+    hsize_t last_end;
+    hid_t did;
+    hid_t mtype;      /* memory datatype ID */
+    char **temp_mem;
+    int request_size;
+    int request_size_limit;
+} multidataset_array;
+
+int init_multidataset();
+int finalize_multidataset();
+//hid_t get_dataset_id(const char* name, hid_t gid);
+/*
+int register_dataset_recycle(hid_t did);
+int register_dataspace_recycle(hid_t dsid);
+int register_memspace_recycle(hid_t msid);
+int register_multidataset(const char* name, void *buf, hid_t did, hid_t dsid, hid_t msid, hid_t mtype, int write);
+int dataset_recycle_all();
+int dataspace_recycle_all();
+int memspace_recycle_all();
+*/
+int register_multidataset_request_append(const char *name, hid_t gid, void *buf, hsize_t data_size, hid_t mtype);
+int flush_multidatasets();
+//int check_write_status();
+#endif

--- a/threaded_io_test.cc
+++ b/threaded_io_test.cc
@@ -217,6 +217,11 @@ int main(int argc, char* argv[]) {
   std::cout <<"number events: "<<ievt.load() -nLanes<<std::endl;
   std::cout <<"----------"<<std::endl;
 
+#ifdef H5_TIMING_ENABLE
+  finalize_timers();
+#endif
+  finalize_multidataset();
+
   source->printSummary();
   out->printSummary();
 }

--- a/threaded_io_test.cc
+++ b/threaded_io_test.cc
@@ -51,9 +51,9 @@ namespace {
 int main(int argc, char* argv[]) {
   using namespace cce::tf;
 
-  if(not (argc > 1 and argc < 8) ) {
-    std::cout <<"1 to 6 arguments required\n"
-                "threaded_io_test <Source configuration> [# threads[/useIMT]] [# conconcurrent events] [wait time scale factor] [max # events] [<Outputer configuration>]\n";
+  if(not (argc > 1 and argc < 10) ) {
+    std::cout <<"1 to 9 arguments required\n"
+                "threaded_io_test <Source configuration> [# threads[/useIMT]] [# conconcurrent events] [wait time scale factor] [max # events] [<Outputer configuration>] [<max batch size>] [<I/O type>: 1 is default, 0 is aggregation, 2 is HDF5 optimized]\n";
     return 1;
   }
 

--- a/threaded_io_test.cc
+++ b/threaded_io_test.cc
@@ -16,6 +16,8 @@
 #include "tbb/task_group.h"
 #include "tbb/global_control.h"
 #include "tbb/task_arena.h"
+#include "H5Timing.h"
+#include "multidataset_plugin.h"
 
 extern int max_batch_size;
 extern int hdf_method;

--- a/threaded_io_test.cc
+++ b/threaded_io_test.cc
@@ -57,6 +57,10 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
+#ifdef H5_TIMING_ENABLE
+  init_timers();
+#endif
+
   init_multidataset();
   int parallelism = tbb::this_task_arena::max_concurrency();
   bool useIMT=false;
@@ -217,10 +221,10 @@ int main(int argc, char* argv[]) {
   std::cout <<"number events: "<<ievt.load() -nLanes<<std::endl;
   std::cout <<"----------"<<std::endl;
 
+  finalize_multidataset();
 #ifdef H5_TIMING_ENABLE
   finalize_timers();
 #endif
-  finalize_multidataset();
 
   source->printSummary();
   out->printSummary();


### PR DESCRIPTION
Contains the following features:
1. A bug fix for batch size. If the total number of objects is not divisible by the batch size, some objects are not written. This issue is fixed.
2. Arguments for controling the batch size and HDF5 method
3. Two additional HDF5 strategies: aggregation and H5O implementation.
4. H5Timing support for time details (disabled by default)
5. A typo preventing compiling in the existing master branch