### PR TITLE
Adjust to RNTuple API: GetSubFields -> Get(Const|Mutable)Subfields

### DIFF
--- a/SerialRNTupleSource.cc
+++ b/SerialRNTupleSource.cc
@@ -29,7 +29,7 @@ SerialRNTupleSource::SerialRNTupleSource(unsigned iNLanes, unsigned long long iN
   bool hasEventID = false;
   bool hasEventAux = false;
   auto const& model = events_->GetModel();
-  auto const& subfields = model.GetConstFieldZero().GetSubFields();
+  auto const& subfields = model.GetConstFieldZero().GetConstSubfields();
   std::vector<std::string> fieldIDs;
   fieldIDs.reserve(subfields.size());
   std::vector<std::string> fieldType;

--- a/SerialRNTupleTFileSource.cc
+++ b/SerialRNTupleTFileSource.cc
@@ -32,7 +32,7 @@ SerialRNTupleTFileSource::SerialRNTupleTFileSource(unsigned iNLanes, unsigned lo
   bool hasEventID = false;
   bool hasEventAux = false;
   auto const& model = events_->GetModel();
-  auto const& subfields = model.GetConstFieldZero().GetSubFields();
+  auto const& subfields = model.GetConstFieldZero().GetConstSubfields();
   std::vector<std::string> fieldIDs;
   fieldIDs.reserve(subfields.size());
   std::vector<std::string> fieldType;


### PR DESCRIPTION
This is introduced in ROOT f39e1c27423c2c51b26c6c175145ddd477a24390